### PR TITLE
[Fix] 업로드 로그 분석 탭 클릭시 상태 초기화

### DIFF
--- a/frontend/src/components/LogViewer.js
+++ b/frontend/src/components/LogViewer.js
@@ -119,9 +119,6 @@ const LogViewer = () => {
 
   const handleTabChange = (newTab) => {
     setActiveTab(newTab);
-    if (newTab === 'upload' && lastUploadedFileRef.current) {
-      setUploadedFile(lastUploadedFileRef.current);
-    }
   };
 
   const handleUploadStatusChange = ({ success, error }) => {
@@ -144,6 +141,8 @@ const LogViewer = () => {
   const handleOtherFileUpload = () => {
     lastUploadedFileRef.current = null;
     setUploadedFile(null);
+    setUploadSuccess(false);
+    setUploadError(null);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## #️⃣ Issue Number  
#18   

## ✨ 작업 내용  
- 로그 분석 탭 전환 시 데이터 초기화 버그 수정
- 데이터 초기화는 "다른 파일 업로드" 버튼 클릭 시에만 발생하도록 변경
- 업로드 관련 상태(파일, 성공, 에러) 초기화 로직 개선

## 🔍 참고 사항  
- `handleTabChange` 함수에서 불필요한 데이터 초기화 로직 제거
- `handleOtherFileUpload` 함수에서 모든 업로드 관련 상태를 한번에 초기화하도록 수정
- 사용자 경험 개선을 위해 의도적인 액션(다른 파일 업로드 버튼 클릭)에서만 데이터 초기화 발생

## ✅ Check List  
- [x] ⚙️ 코드가 정상적으로 컴파일되나요?  
- [x] 🔀 merge할 브랜치의 위치를 확인했나요?  
- [x] 🏷️ Label을 지정했나요?
